### PR TITLE
build(package): marked@^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "example": "example"
   },
   "devDependencies": {
-    "marked": "^0.3.12",
+    "marked": "^0.4.0",
     "mocha": "^3.1.2"
   },
   "repository": {


### PR DESCRIPTION
It looks like npm doesn't like having a peer dependency higher that the actual devDep.